### PR TITLE
Send password/confirmation in signup payload

### DIFF
--- a/app/models/user.js
+++ b/app/models/user.js
@@ -27,6 +27,22 @@ export default DS.Model.extend({
   username: attr('string'),
 
   /**
+    User's password.
+
+     @attribute password
+     @type String
+  */
+  password: attr('string'),
+
+  /**
+    User's password confirmation.
+
+     @attribute password
+     @type String
+  */
+  passwordConfirmation: attr('string'),
+
+  /**
     The text of a user's profile.
 
     @attribute profileText


### PR DESCRIPTION
Companion to https://github.com/lbaillie/assemble-api/pull/3. These
attributes weren't being sent to the Rails app during the signup
request, adding them here seems to fix it.

Disclaimer: I am not an front-end developer, so this may not be a good solution!

Here are some screens of it working (along with corresponding back-end changes):

![assemble_-_2017-01-29_11 06 05](https://cloud.githubusercontent.com/assets/1710874/22407089/850d0fd0-e614-11e6-8c98-1b726b01e3ea.png)

![assemble_-_2017-01-29_11 06 19](https://cloud.githubusercontent.com/assets/1710874/22407092/8d77769c-e614-11e6-940a-3620f5f5cca6.png)

Fixes #2