### PR TITLE
Fix map-display test

### DIFF
--- a/tests/integration/components/map-display-test.js
+++ b/tests/integration/components/map-display-test.js
@@ -1,8 +1,17 @@
 import { moduleForComponent, test } from 'ember-qunit';
+import Ember from 'ember';
 import hbs from 'htmlbars-inline-precompile';
 
+let StubGoogleMap = Ember.Service.extend({
+  initMap() {}
+});
+
 moduleForComponent('map-display', 'Integration | Component | map display', {
-  integration: true
+  integration: true,
+  beforeEach() {
+    this.register('service:google-map', StubGoogleMap);
+    this.inject.service('googleMap', { as: 'mapsService' });
+  }
 });
 
 test('it renders', function(assert) {


### PR DESCRIPTION
This test was failing because it was trying to make a real call to the
google maps API. Registering a stub maps service in its place fixes
the issue.

I *think* this should turn the build green, though I'm not sure I got all the details right. Happy to keep submitting PRs though as I learn more about Ember!

Fixes #4 